### PR TITLE
Fix/cards performance

### DIFF
--- a/src/Components/Deck/Cards/Card.js
+++ b/src/Components/Deck/Cards/Card.js
@@ -1,22 +1,34 @@
 import React, { useState } from "react";
 import PropTypes from "prop-types";
-
 import { CardContainer } from "./style";
 import CardDisplay from "./CardDisplay";
 
+import {
+  INITIAL_CARD_POSITION,
+  REMOVE_LIKED_ANIMATION,
+  REMOVE_DISLIKED_ANIMATION,
+  REMOVE_SUPERLIKED_ANIMATION,
+  DISPLAY_SUPERLIKED_BOUNDARY,
+  DISPLAY_LIKED_BOUNDARY,
+  DISPLAY_DISLIKED_BOUNDARY,
+  REMOVE_SUPERLIKED_BOUNDARY,
+  REMOVE_LIKED_BOUNDARY,
+  REMOVE_DISLIKED_BOUNDARY
+} from "../../../Constants";
+
 const Card = ({ stuntDouble, handleAction }) => {
   const [action, setAction] = useState("");
-  const [removeCard, setRemoveCard] = useState(false);
+  const [removeCard, setRemoveCard] = useState(INITIAL_CARD_POSITION);
 
   const animateAction = (id, action) => {
     let removeCard =
       action === "liked"
-        ? { x: 400, opacity: 0 }
+        ? REMOVE_LIKED_ANIMATION
         : action === "disliked"
-        ? { x: -400, opacity: 0 }
+        ? REMOVE_DISLIKED_ANIMATION
         : action === "superliked"
-        ? { y: -400, opacity: 0 }
-        : { x: 0, y: 0 };
+        ? REMOVE_SUPERLIKED_ANIMATION
+        : INITIAL_CARD_POSITION;
 
     setAction(action);
     setRemoveCard(removeCard);
@@ -29,11 +41,11 @@ const Card = ({ stuntDouble, handleAction }) => {
     let yPosition = info.point.y;
 
     let action =
-      xPosition > 50
+      xPosition > DISPLAY_LIKED_BOUNDARY
         ? "liked"
-        : xPosition < -50
+        : xPosition < DISPLAY_DISLIKED_BOUNDARY
         ? "disliked"
-        : yPosition < -50
+        : yPosition < DISPLAY_SUPERLIKED_BOUNDARY
         ? "superliked"
         : "";
 
@@ -44,11 +56,11 @@ const Card = ({ stuntDouble, handleAction }) => {
     let xPosition = info.point.x;
     let yPosition = info.point.y;
 
-    return xPosition > 80
+    return xPosition > REMOVE_LIKED_BOUNDARY
       ? animateAction(id, "liked")
-      : xPosition < -80
+      : xPosition < REMOVE_DISLIKED_BOUNDARY
       ? animateAction(id, "disliked")
-      : yPosition < -80
+      : yPosition < REMOVE_SUPERLIKED_BOUNDARY
       ? animateAction(id, "superliked")
       : setAction("");
   };
@@ -60,7 +72,9 @@ const Card = ({ stuntDouble, handleAction }) => {
       dragConstraints={{ top: 0, right: 0, bottom: 0, left: 0 }}
       onDrag={(e, info) => handleDrag(info)}
       onDragEnd={(e, info) => handleDragEnd(stuntDouble.id, info)}
-      animate={removeCard}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={removeCard}
       actionColour={action}
     >
       <CardDisplay

--- a/src/Components/Deck/Cards/style.js
+++ b/src/Components/Deck/Cards/style.js
@@ -33,6 +33,7 @@ export const CardContainer = styled(motion.div).attrs(props => ({
   position: absolute;
   border-radius: 10px;
   overflow: hidden;
+  cursor: pointer;
 
   width: 320px;
   height: 480px;

--- a/src/Components/Deck/Deck.js
+++ b/src/Components/Deck/Deck.js
@@ -10,14 +10,13 @@ import {
 import Results from "./Results/Results";
 import Card from "./Cards/Card";
 
+import { AnimatePresence } from "framer-motion";
 import { CardsContainer } from "./Cards/style";
 
 class Deck extends Component {
   handleAction = (id, action) => {
-    setTimeout(() => {
-      this.props.addStuntDouble(id, action);
-      this.props.removeStuntDouble(id);
-    }, 500);
+    this.props.addStuntDouble(id, action);
+    this.props.removeStuntDouble(id);
   };
 
   render() {
@@ -26,15 +25,17 @@ class Deck extends Component {
       <div>
         {stuntDoublesList.length > 0 ? (
           <CardsContainer>
-            {stuntDoublesList.map(stuntDouble => {
-              return (
-                <Card
-                  key={stuntDouble.id}
-                  stuntDouble={stuntDouble}
-                  handleAction={this.handleAction}
-                />
-              );
-            })}
+            <AnimatePresence>
+              {stuntDoublesList.map(stuntDouble => {
+                return (
+                  <Card
+                    key={stuntDouble.id}
+                    stuntDouble={stuntDouble}
+                    handleAction={this.handleAction}
+                  />
+                );
+              })}
+            </AnimatePresence>
           </CardsContainer>
         ) : (
           <Results />

--- a/src/Constants.js
+++ b/src/Constants.js
@@ -1,0 +1,27 @@
+export const INITIAL_CARD_POSITION = { x: 0, y: 0 };
+
+export const REMOVE_LIKED_ANIMATION = {
+  x: 400,
+  opacity: 0,
+  pointerEvents: "none"
+};
+
+export const REMOVE_DISLIKED_ANIMATION = {
+  x: -400,
+  opacity: 0,
+  pointerEvents: "none"
+};
+
+export const REMOVE_SUPERLIKED_ANIMATION = {
+  y: -400,
+  opacity: 0,
+  pointerEvents: "none"
+};
+
+export const DISPLAY_SUPERLIKED_BOUNDARY = -40;
+export const DISPLAY_LIKED_BOUNDARY = 40;
+export const DISPLAY_DISLIKED_BOUNDARY = -40;
+
+export const REMOVE_SUPERLIKED_BOUNDARY = -80;
+export const REMOVE_LIKED_BOUNDARY = 80;
+export const REMOVE_DISLIKED_BOUNDARY = -80;


### PR DESCRIPTION
https://github.com/GawahChan/SD-Tinder/issues/1

Fixed performance bug by instead of using setTimeout to deal with unmounting, we can use framer-motion to animate when a component unmounts. 

Since framer-motion gives animation controls when a component unmounts, we can set pointer-events:'none' when the component is unmounting. This prevents user from clicking on the previous card s which was the cause of the duplications.